### PR TITLE
add possibility to control segmentation and color space conversion

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,12 @@
       "reward_scale": 1.0,
       "reward_functions": {
       },
-      "reward_aggregations": []
+      "reward_aggregations": [],
+      "preliminary_transformer": {
+
+        "use_segmentation": true,
+        "colorspace_conversion": null
+      }
     }
   },
   "model": {

--- a/scripts/collect.py
+++ b/scripts/collect.py
@@ -31,7 +31,8 @@ def collect(model_directory, output_dir, episodes, max_steps):
     env = launch_env()
     env_seed = config['environment']['core'].get('seed', global_seed)
     env.seed(env_seed)
-    preprocessor = PreliminaryTransformer()
+    preliminary_transformer_kwargs = config['environment']['wrapper'].get('preliminary_transformer', {})
+    preprocessor = PreliminaryTransformer(**preliminary_transformer_kwargs)
     transformer = Transformer()
 
     total_samples = 0

--- a/utils/reward_shaping/env_utils.py
+++ b/utils/reward_shaping/env_utils.py
@@ -47,6 +47,9 @@ class PreliminaryTransformer:
         """
         self.shape = shape
         self.use_segmentation = use_segmentation
+        if isinstance(colorspace_conversion, str):
+            assert hasattr(cv2, colorspace_conversion), f"cv2 doesn't have {colorspace_conversion} colorspace conversion method"
+            colorspace_conversion = getattr(cv2, colorspace_conversion)
         self.colorspace_conversion = colorspace_conversion
 
     def reset(self, observation):

--- a/utils/reward_shaping/env_utils_test.py
+++ b/utils/reward_shaping/env_utils_test.py
@@ -3,9 +3,11 @@
 import matplotlib.pyplot as plt
 import os
 import cv2
+import numpy as np
 
 from features.straight.straight import line_approx
 from utils.reward_shaping.env_utils import PreliminaryTransformer
+from utils.env import launch_env
 
 
 def main():
@@ -24,6 +26,49 @@ def main():
     plt.imshow(transformed_frame[0, :, :], cmap='gray', vmin=0, vmax=255)
     plt.waitforbuttonpress()
 
+def save_observation_as_image(obs, filename, image_dir='tests/colorspace/', colorspace_conversion=None):
+    if obs.shape[0] == 1:
+        # to save in grayscale we need to remove channel
+        obs = np.squeeze(obs, axis=0)
+    elif obs.shape[0] == 3:
+        # to save in rgb we need to transpose observation (channel last)
+        obs = np.transpose(obs, axes=(1, 2, 0))
+    if colorspace_conversion:
+        obs = cv2.cvtColor(obs, colorspace_conversion)
+
+    os.makedirs(image_dir, exist_ok=True)
+    cv2.imwrite(f'{image_dir}{filename}', obs)
+
+def colorspace_test():
+    env = launch_env()
+
+    observation = env.reset()
+
+    save_observation_as_image(observation, filename='original_observation.png', colorspace_conversion=cv2.COLOR_RGB2BGR)
+
+    print(f'original shape: {observation.shape}')
+
+    segmenation_transformer = PreliminaryTransformer(use_segmentation=True)
+    segmenation_obs = segmenation_transformer.transform(observation)
+    save_observation_as_image(segmenation_obs, filename='with_segmentation_observation.png')
+
+    grayscale_transformer = PreliminaryTransformer(use_segmentation=False, colorspace_conversion=cv2.COLOR_RGB2GRAY)
+    grayscale_obs = grayscale_transformer.transform(observation)
+    save_observation_as_image(grayscale_obs, filename='grayscale_observation.png')
+
+    rgb_transformer = PreliminaryTransformer(use_segmentation=False, colorspace_conversion=None)
+    rgb_obs = rgb_transformer.transform(observation)
+    save_observation_as_image(rgb_obs, filename='rgb_observation.png', colorspace_conversion=cv2.COLOR_RGB2BGR)
+
+    hsv_transformer = PreliminaryTransformer(use_segmentation=False, colorspace_conversion=cv2.COLOR_RGB2HSV)
+    hsv_obs = hsv_transformer.transform(observation)
+    save_observation_as_image(hsv_obs, filename='hsv_observation.png', colorspace_conversion=cv2.COLOR_HSV2BGR)
+
+    yuv_transformer = PreliminaryTransformer(use_segmentation=False, colorspace_conversion=cv2.COLOR_RGB2YUV)
+    yuv_obs = yuv_transformer.transform(observation)
+    save_observation_as_image(yuv_obs, filename='yuv_observation.png', colorspace_conversion=cv2.COLOR_YUV2BGR)
+
 
 if __name__ == '__main__':
-  main()
+    # main()
+    colorspace_test()

--- a/utils/reward_shaping/env_utils_test.py
+++ b/utils/reward_shaping/env_utils_test.py
@@ -48,9 +48,9 @@ def colorspace_test():
 
     print(f'original shape: {observation.shape}')
 
-    segmenation_transformer = PreliminaryTransformer(use_segmentation=True)
-    segmenation_obs = segmenation_transformer.transform(observation)
-    save_observation_as_image(segmenation_obs, filename='with_segmentation_observation.png')
+    segmentation_transformer = PreliminaryTransformer(use_segmentation=True)
+    segmentation_obs = segmentation_transformer.transform(observation)
+    save_observation_as_image(segmentation_obs, filename='with_segmentation_observation.png')
 
     grayscale_transformer = PreliminaryTransformer(use_segmentation=False, colorspace_conversion=cv2.COLOR_RGB2GRAY)
     grayscale_obs = grayscale_transformer.transform(observation)
@@ -69,6 +69,15 @@ def colorspace_test():
     save_observation_as_image(yuv_obs, filename='yuv_observation.png', colorspace_conversion=cv2.COLOR_YUV2BGR)
 
 
+def create_from_config_test():
+    segmentation_transformer = PreliminaryTransformer(use_segmentation=True, colorspace_conversion=None)
+    grayscale_transformer = PreliminaryTransformer(use_segmentation=False, colorspace_conversion='COLOR_RGB2GRAY')
+    rgb_transformer = PreliminaryTransformer(use_segmentation=False, colorspace_conversion=None)
+    hsv_transformer = PreliminaryTransformer(use_segmentation=False, colorspace_conversion='COLOR_RGB2HSV')
+    yuv_transformer = PreliminaryTransformer(use_segmentation=False, colorspace_conversion='COLOR_RGB2YUV')
+
+
 if __name__ == '__main__':
     # main()
     colorspace_test()
+    create_from_config_test()


### PR DESCRIPTION
Результаты тестов:
https://imgur.com/a/uDdQjaX  
(rgb, hsv и yuv не отличаются, но так и должно быть, так как перед сохранением я перевожу все в `BGR`, т.к. сохраняю через opencv).

В идеале параметры `use_segmentation=True, colorspace_conversion=None` добавить в конфиг, чтобы можно было задавать оттуда и сохранять вместе с весами