### PR TITLE
set default resample filter as `Image.BICUBIC`

### DIFF
--- a/utils/reward_shaping/env_utils.py
+++ b/utils/reward_shaping/env_utils.py
@@ -62,7 +62,7 @@ class PreliminaryTransformer:
         if self.use_segmentation:
             obs = line_approx(np.array(obs, dtype=np.uint8))
 
-        frame_lines_resized = np.array(Image.fromarray(obs).resize(self.shape))
+        frame_lines_resized = np.array(Image.fromarray(obs).resize(self.shape, resample=Image.BICUBIC))
         height = frame_lines_resized.shape[0]
         frame_lines_clipped = frame_lines_resized[height // 3:height]
         if frame_lines_clipped.ndim == 2:


### PR DESCRIPTION
**Осторожно**: до [версии `7.0`](https://pillow.readthedocs.io/en/stable/releasenotes/7.0.0.html#default-resampling-filter) выбором по умолчанию был `Image.NEAREST`, а после `Image.BICUBIC ` (подробнее про фильтры [здесь](https://pillow.readthedocs.io/en/stable/handbook/concepts.html#concept-filters)).

Зафиксировав, можно добиться одинакового результата